### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ client.transactions.find_by_id('my_company', '123')
 params = {
   adjustmentReason: 8,
   adjustmentDescription: 'New line item.',
-  new_transaction: { ... }
+  newTransaction: { ... }
 }
 
 client.transactions.adjust('my_company', 'my_code', params)


### PR DESCRIPTION
Update README to prevent end user from getting this response from Avatax: 
```
{"error"=>{"code"=>"ValueRequiredError", "message"=>"Field newTransaction is required.", "target"=>"IncorrectData"}
```