### PR TITLE
[SC-7100] Upgrade to Support Faraday of Version > 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Ruby runtime as the parent image
+FROM ruby:2.6.5
+
+# Set environment variables for bundler
+ENV BUNDLE_PATH=/bundle \
+    GEM_HOME=/bundle \
+    BUNDLE_BIN=/bundle/bin \
+    PATH=./bin:/bundle/bin:$PATH
+
+# Update and install base dependencies (add any system dependencies the gem might require)
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+
+# Create and set the working directory
+WORKDIR /usr/src/app
+
+# Copy Gemfile and Gemfile.lock and install gems
+COPY Gemfile* ./
+COPY *.gemspec ./
+
+# Copy the main application into the container
+COPY . .
+
+RUN bundle install

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'faraday'
-  spec.add_runtime_dependency 'faraday_middleware'
+  spec.add_runtime_dependency 'faraday', '>= 2.7.1', '~> 2.7'
+  spec.add_runtime_dependency 'faraday-net_http_persistent'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 12.3.3"

--- a/lib/avatax.rb
+++ b/lib/avatax.rb
@@ -1,6 +1,6 @@
 require 'active_support/all'
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/net_http_persistent'
 
 require 'avatax/version'
 require 'avatax/code'

--- a/lib/avatax/client.rb
+++ b/lib/avatax/client.rb
@@ -70,11 +70,7 @@ module Avatax
     def build_default_connection
       Faraday.new(url: @configuration.base_url) do |conn|
         conn.request :json
-        conn.request(
-          :basic_auth,
-          @configuration.username,
-          @configuration.password
-        )
+        conn.request :authorization, :basic, @configuration.username, @configuration.password
 
         conn.headers = @configuration.headers
 

--- a/lib/avatax/version.rb
+++ b/lib/avatax/version.rb
@@ -1,3 +1,3 @@
 module Avatax
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Dockerizes the app to avoid the headache of local development with an old version of Ruby on M1.

Upgrades Faraday following the docs:
- https://github.com/lostisland/faraday/blob/main/UPGRADING.md
- https://lostisland.github.io/faraday/#/middleware/included/authentication

Tested locally. Built the new version of the gem, initialized a client in `irb`, treid running 
```
params = {
    line1: '350 State St.',
    city: 'Salt Lake City',
    region: 'CA',
    postalCode: '84111',
    country: 'US'
}
resp = client.tax_rates.get(:by_address, params)

params = { country: 'US', postalCode: '84111' }
resp = client.tax_rates.get(:by_postal_code, params)

```
Both returned something.